### PR TITLE
blueskyのURLプレビューに対応

### DIFF
--- a/src/plugins/bluesky.ts
+++ b/src/plugins/bluesky.ts
@@ -1,0 +1,35 @@
+import { get } from '../utils/got.js';
+import type summary from '../summary.js';
+import * as cheerio from 'cheerio';
+
+export function test(url: URL): boolean {
+	return url.hostname === 'bsky.app';
+}
+
+export async function summarize(url: URL): Promise<summary> {
+	// HEADで取ると404が返るためGETのみで取得
+	const body = await get(url.href);
+	const $ = cheerio.load(body);
+
+	const title = $('meta[property="og:title"]').attr('content');
+
+	const description = $('meta[property="og:description"]').attr('content');
+
+	const thumbnail = $('meta[property="og:image"]').attr('content');
+
+	return {
+		title: title ? title.trim() : null,
+		icon: 'https://bsky.app/static/favicon-32x32.png',
+		description: description ? description.trim() : null,
+		thumbnail: thumbnail ? thumbnail.trim() : null,
+		// oEmbedのhtmlがiframeではないのでsummalyで表示できない
+		player: {
+			url: null,
+			width: null,
+			height: null,
+			allow: [],
+		},
+		sitename: 'Bluesky Social',
+		activityPub: null,
+	};
+}

--- a/src/plugins/bluesky.ts
+++ b/src/plugins/bluesky.ts
@@ -1,6 +1,6 @@
+import * as cheerio from 'cheerio';
 import { get } from '../utils/got.js';
 import type summary from '../summary.js';
-import * as cheerio from 'cheerio';
 
 export function test(url: URL): boolean {
 	return url.hostname === 'bsky.app';

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,10 +1,12 @@
 import * as amazon from './amazon.js';
+import * as bluesky from './bluesky.js';
 import * as wikipedia from './wikipedia.js';
 import * as branchIoDeeplinks from './branchio-deeplinks.js';
 import { SummalyPlugin } from '@/iplugin.js';
 
 export const plugins: SummalyPlugin[] = [
 	amazon,
+	bluesky,
 	wikipedia,
 	branchIoDeeplinks,
 ];


### PR DESCRIPTION
標準のscrapingメソッドを利用するとHEADで404が返るため、GETのみを行いogpの内容を取得するようにしました。
oEmbedは提供はされているもののsummalyが対応しているiframe形式ではないため対応見送りにしています。

対応前
![image](https://github.com/user-attachments/assets/f29680c2-9091-4168-8749-870e4ce632c6)

対応後
![image](https://github.com/user-attachments/assets/b5abfc98-b7d3-4987-8bf6-d196a625eee0)
